### PR TITLE
Deployment fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-# We use html-proofer for CI builds
-gem "html-proofer", "3.4.0"
+group :development do
+  # We use html-proofer for CI builds
+  gem "html-proofer", "3.4.0"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: > # this means to ignore newlines until "baseurl:"
   interested in Free and Open Source software. We have weekly
   meetings, talks, and Linux Installfests every semester.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://opensourcecornell.org"
 twitter_username: OpenCornell
 github_username:  OpenSourceCornell
 

--- a/_config.yml
+++ b/_config.yml
@@ -41,3 +41,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - scripts/
+  - vendor/


### PR DESCRIPTION
- Don't install html-proofer (move it into a group that we can exclude at deployment time)
- Exclude the `vendor` directory
- Set the site URL in the Jekyll config

Think we should put the post-receive hook in a repo (here or elsewhere)?