### PR TITLE
Generate events iCalendar file

### DIFF
--- a/_pages/events.html
+++ b/_pages/events.html
@@ -6,6 +6,7 @@ title: "Events"
 <div class="wrapper">
     <section class="events" aria-labeledby="events">
         <h2 id="events">Events</h2>
+        <a href="{{ '/events/calendar.ics' | relative_url }}">(iCalendar)</a>
         <ul>
             {% assign events = site.events | sort: 'date' | reverse %}
             {% for post in events %}

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -127,6 +127,7 @@ permalink: /
                     {% endfor %}
                 </ul>
                 <a href="{{ '/events' | relative_url }}">All Events &gt;</a>
+                <a href="{{ '/events/calendar.ics' | relative_url }}">(iCalendar)</a>
             </div>
         </section>
         <section class="links" aria-labeledby="links">

--- a/events/calendar.ics
+++ b/events/calendar.ics
@@ -1,0 +1,18 @@
+---
+layout:
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//OpenSourceCornell/Events//NONSGML v1.0//EN
+{% for event in site.events %}BEGIN:VEVENT
+UID:{{ event.date | date: "%Y-%m-%d-" }}{{ event.slug | strip }}@opensourcecornell.org
+SUMMARY:{{ event.title | strip }}
+URL:{{ event.url | absolute_url | strip }}
+LOCATION:{{ event.location | strip }}
+DTSTART:{{ event.start_time | date: "%Y%m%dT%H%M%SZ" }}
+{% if event.end_time %}DTEND:{{ event.end_time | date: "%Y%m%dT%H%M%SZ" }}{% endif %}
+DTSTAMP:{{ event.date | date: "%Y%m%dT%H%M%SZ" }}
+DESCRIPTION;ALTREP="{{ event.url | absolute_url | strip }}":{{ event.content | strip_html | strip | newline_to_br | strip_newlines | replace: "<br />", " " }}
+CLASS:PUBLIC
+END:VEVENT
+{% endfor %}END:VCALENDAR


### PR DESCRIPTION
This patch adds a generated iCalendar file at the URL
`/events/calendar.ics` and links to it from the home page and events
page.  The description field isn't always nice looking, but it's the
best I've been able to get it.

The generated iCalendar was validated with [this online
validator][validator].

[validator]: https://icalendar.org/validator.html