### PR TITLE
Add event page for 2017/03/06 weekly meeting

### DIFF
--- a/_events/2017-03-06-weekly-meeting.md
+++ b/_events/2017-03-06-weekly-meeting.md
@@ -1,0 +1,22 @@
+---
+layout: event
+title: Weekly Meeting
+start_time: 2017-03-06T18:00:00-05
+end_time: 2017-03-06T19:00:00-05
+location: Gates Hall 416
+external_url:
+---
+
+Pining for summer after the snowfall this weekend? Why not come
+discuss summer plans with OpenSourceCornell? This week, we'll be
+talking about how you can get involved with open source projects over
+the summer, including
+
+  * [Google Summer of Code][gsoc],
+  * [Rails Girls Summer of Code][rgsoc],
+  * and companies based around open source (such as [Mozilla][mozilla] and [Red Hat][redhat]).
+
+[gsoc]: https://summerofcode.withgoogle.com/
+[rgsoc]: https://railsgirlssummerofcode.org/
+[mozilla]: https://careers.mozilla.org/university/
+[redhat]: https://www.redhat.com/en/jobs/categories/internships


### PR DESCRIPTION
Pining for summer after the snowfall this weekend? Why not come
discuss summer plans with OpenSourceCornell? This week, we'll be
talking about how you can get involved with open source projects over
the summer, including

  * [Google Summer of Code][gsoc],
  * [Rails Girls Summer of Code][rgsoc],
  * and companies based around open source (such as [Mozilla][mozilla] and [Red Hat][redhat]).

[gsoc]: https://summerofcode.withgoogle.com/
[rgsoc]: https://railsgirlssummerofcode.org/
[mozilla]: https://careers.mozilla.org/university/
[redhat]: https://www.redhat.com/en/jobs/categories/internships